### PR TITLE
Simplify types

### DIFF
--- a/cpp/demo/biharmonic/main.cpp
+++ b/cpp/demo/biharmonic/main.cpp
@@ -141,7 +141,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 // Inside the `main` function, we begin by defining a mesh of the
 // domain. As the unit square is a very standard domain, we can use a

--- a/cpp/demo/codim_0_assembly/main.cpp
+++ b/cpp/demo/codim_0_assembly/main.cpp
@@ -22,7 +22,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 int main(int argc, char* argv[])
 {

--- a/cpp/demo/hyperelasticity/main.cpp
+++ b/cpp/demo/hyperelasticity/main.cpp
@@ -36,7 +36,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 /// Hyperelastic problem class
 class HyperElasticProblem

--- a/cpp/demo/mixed_poisson/main.cpp
+++ b/cpp/demo/mixed_poisson/main.cpp
@@ -110,7 +110,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 int main(int argc, char* argv[])
 {

--- a/cpp/demo/poisson/main.cpp
+++ b/cpp/demo/poisson/main.cpp
@@ -94,7 +94,7 @@
 
 using namespace dolfinx;
 using T = PetscScalar;
-using U = typename dolfinx::scalar_value_type_t<T>;
+using U = typename dolfinx::scalar_value_t<T>;
 
 // Then follows the definition of the coefficient functions (for $f$ and
 // $g$), which are derived from the {cpp:class}`Expression` class in

--- a/cpp/demo/poisson_matrix_free/main.cpp
+++ b/cpp/demo/poisson_matrix_free/main.cpp
@@ -245,7 +245,7 @@ void solver(MPI_Comm comm)
 int main(int argc, char* argv[])
 {
   using T = PetscScalar;
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
   init_logging(argc, argv);
   MPI_Init(&argc, &argv);
   solver<T, U>(MPI_COMM_WORLD);

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -16,7 +16,7 @@ namespace dolfinx
 /// point real or complex types. Note that this concept is different to
 /// std::floating_point which does not include std::complex.
 template <class T>
-concept scalar = std::is_floating_point_v<T>
+concept scalar = std::floating_point<T>
                  || std::is_same_v<T, std::complex<typename T::value_type>>;
 
 /// @private These structs are used to get the float/value type from a

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Garth N. Wells
+// Copyright (C) 2023-2025 Garth N. Wells and Paul T. Kühner
 //
 // This file is part of DOLFINx (https://www.fenicsproject.org)
 //

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -19,22 +19,21 @@ template <class T>
 concept scalar = std::is_floating_point_v<T>
                  || std::is_same_v<T, std::complex<typename T::value_type>>;
 
-
 /// @private These structs are used to get the float/value type from a
 /// template argument, including support for complex types.
 template <scalar T, typename = void>
-struct scalar_value_type
+struct scalar_value
 {
   /// @internal
-  typedef T value_type;
+  typedef T type;
 };
 /// @private
 template <scalar T>
-struct scalar_value_type<T, std::void_t<typename T::value_type>>
+struct scalar_value<T, std::void_t<typename T::value_type>>
 {
-  typedef typename T::value_type value_type;
+  typedef typename T::value_type type;
 };
 /// @private Convenience typedef
 template <scalar T>
-using scalar_value_type_t = typename scalar_value_type<T>::value_type;
+using scalar_value_type_t = typename scalar_value<T>::type;
 } // namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -35,5 +35,5 @@ struct scalar_value<T, std::void_t<typename T::value_type>>
 };
 /// @private Convenience typedef
 template <scalar T>
-using scalar_value_type_t = typename scalar_value<T>::type;
+using scalar_value_t = typename scalar_value<T>::type;
 } // namespace dolfinx

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -16,9 +16,10 @@ namespace dolfinx
 /// point real or complex types. Note that this concept is different to
 /// std::floating_point which does not include std::complex.
 template <class T>
-concept scalar
-    = std::is_floating_point_v<T> || std::is_same_v<T, std::complex<double>>
-      || std::is_same_v<T, std::complex<float>>;
+concept scalar = std::is_floating_point_v<T>
+                 || std::is_same_v<T, std::complex<typename T::value_type>>;
+
+
 /// @private These structs are used to get the float/value type from a
 /// template argument, including support for complex types.
 template <scalar T, typename = void>

--- a/cpp/dolfinx/common/types.h
+++ b/cpp/dolfinx/common/types.h
@@ -10,6 +10,8 @@
 #include <concepts>
 #include <type_traits>
 
+#include <basix/mdspan.hpp>
+
 namespace dolfinx
 {
 /// @private This concept is used to constrain the a template type to floating
@@ -36,4 +38,11 @@ struct scalar_value<T, std::void_t<typename T::value_type>>
 /// @private Convenience typedef
 template <scalar T>
 using scalar_value_t = typename scalar_value<T>::type;
+
+/// Namespace containing the `mdspan` implementation
+namespace md = MDSPAN_IMPL_STANDARD_NAMESPACE;
+
+/// @private DofMap span data layout
+using DofMapSpan = md::mdspan<const std::int32_t, md::dextents<std::size_t, 2>>;
+
 } // namespace dolfinx

--- a/cpp/dolfinx/fem/DirichletBC.h
+++ b/cpp/dolfinx/fem/DirichletBC.h
@@ -255,7 +255,7 @@ std::array<std::vector<std::int32_t>, 2> locate_dofs_geometrical(
 /// space (trial space) and degrees of freedom to which the boundary
 /// condition applies.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class DirichletBC
 {
 private:

--- a/cpp/dolfinx/fem/Expression.h
+++ b/cpp/dolfinx/fem/Expression.h
@@ -35,7 +35,7 @@ namespace dolfinx::fem
 /// @tparam T The scalar type
 /// @tparam U The mesh geometry scalar type
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class Expression
 {
 public:

--- a/cpp/dolfinx/fem/Form.h
+++ b/cpp/dolfinx/fem/Form.h
@@ -41,7 +41,7 @@ enum class IntegralType : std::int8_t
 
 /// @brief Represents integral data, containing the integral ID, the
 /// kernel, and a list of entities to integrate over.
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 struct integral_data
 {
   /// @brief Create a structure to hold integral data.
@@ -134,7 +134,7 @@ struct integral_data
 /// @tparam U Float (real) type used for the finite element and geometry.
 /// @tparam Kern Element kernel.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class Form
 {
 public:

--- a/cpp/dolfinx/fem/Function.h
+++ b/cpp/dolfinx/fem/Function.h
@@ -41,7 +41,7 @@ class Expression;
 /// @tparam T The function scalar type.
 /// @tparam U The mesh geometry scalar type.
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 class Function
 {
 public:

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -60,7 +60,7 @@ using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 template <dolfinx::scalar T>
 void assemble_cells(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x,
+    std::span<const scalar_value_t<T>> x,
     std::span<const std::int32_t> cells,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -84,7 +84,7 @@ void assemble_cells(
   const int ndim1 = bs1 * num_dofs1;
   std::vector<T> Ae(ndim0 * ndim1);
   std::span<T> _Ae(Ae);
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over active cells
   assert(cells0.size() == cells.size());
@@ -194,7 +194,7 @@ void assemble_cells(
 template <dolfinx::scalar T>
 void assemble_exterior_facets(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -213,7 +213,7 @@ void assemble_exterior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   const int num_dofs0 = dmap0.extent(1);
   const int num_dofs1 = dmap1.extent(1);
   const int ndim0 = bs0 * num_dofs0;
@@ -333,7 +333,7 @@ void assemble_exterior_facets(
 template <dolfinx::scalar T>
 void assemble_interior_facets(
     la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<const DofMap&, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -352,7 +352,7 @@ void assemble_interior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
@@ -493,7 +493,7 @@ void assemble_interior_facets(
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_matrix(
     la::MatSet<T> auto mat_set, const Form<T, U>& a,
-    std::span<const scalar_value_type_t<T>> x, std::span<const T> constants,
+    std::span<const scalar_value_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients,
     std::span<const std::int8_t> bc0, std::span<const std::int8_t> bc1)

--- a/cpp/dolfinx/fem/assemble_matrix_impl.h
+++ b/cpp/dolfinx/fem/assemble_matrix_impl.h
@@ -12,6 +12,7 @@
 #include "traits.h"
 #include "utils.h"
 #include <algorithm>
+#include <dolfinx/common/types.h>
 #include <dolfinx/la/utils.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
@@ -24,11 +25,6 @@
 
 namespace dolfinx::fem::impl
 {
-/// @brief Typedef
-using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    const std::int32_t,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-
 /// @brief Execute kernel over cells and accumulate result in matrix.
 /// @tparam T Matrix/form scalar type.
 /// @param mat_set Function that accumulates computed entries into a
@@ -59,12 +55,11 @@ using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 /// mesh
 template <dolfinx::scalar T>
 void assemble_cells(
-    la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
-    std::span<const scalar_value_t<T>> x,
-    std::span<const std::int32_t> cells,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
+    la::MatSet<T> auto mat_set, DofMapSpan x_dofmap,
+    std::span<const scalar_value_t<T>> x, std::span<const std::int32_t> cells,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap1,
     fem::DofTransformKernel<T> auto P1T, std::span<const std::int8_t> bc0,
     std::span<const std::int8_t> bc1, FEkernel<T> auto kernel,
     std::span<const T> coeffs, int cstride, std::span<const T> constants,
@@ -193,12 +188,12 @@ void assemble_cells(
 /// permutations are not required.
 template <dolfinx::scalar T>
 void assemble_exterior_facets(
-    la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
+    la::MatSet<T> auto mat_set, DofMapSpan x_dofmap,
     std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap1,
     fem::DofTransformKernel<T> auto P1T, std::span<const std::int8_t> bc0,
     std::span<const std::int8_t> bc1, FEkernel<T> auto kernel,
     std::span<const T> coeffs, int cstride, std::span<const T> constants,
@@ -332,7 +327,7 @@ void assemble_exterior_facets(
 /// permutations are not required.
 template <dolfinx::scalar T>
 void assemble_interior_facets(
-    la::MatSet<T> auto mat_set, mdspan2_t x_dofmap,
+    la::MatSet<T> auto mat_set, DofMapSpan x_dofmap,
     std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<const DofMap&, int, std::span<const std::int32_t>> dofmap0,
@@ -520,7 +515,7 @@ void assemble_matrix(
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     // Geometry dofmap and data
-    mdspan2_t x_dofmap = mesh->geometry().dofmap(cell_type_idx);
+    DofMapSpan x_dofmap = mesh->geometry().dofmap(cell_type_idx);
 
     // Get dofmap data
     std::shared_ptr<const fem::DofMap> dofmap0

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -12,6 +12,7 @@
 #include "utils.h"
 #include <algorithm>
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/types.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
@@ -22,7 +23,7 @@ namespace dolfinx::fem::impl
 {
 /// Assemble functional over cells
 template <dolfinx::scalar T>
-T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_t<T>> x,
+T assemble_cells(DofMapSpan x_dofmap, std::span<const scalar_value_t<T>> x,
                  std::span<const std::int32_t> cells, FEkernel<T> auto fn,
                  std::span<const T> constants, std::span<const T> coeffs,
                  int cstride)
@@ -58,7 +59,7 @@ T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_t<T>> x,
 
 /// Execute kernel over exterior facets and accumulate result
 template <dolfinx::scalar T>
-T assemble_exterior_facets(mdspan2_t x_dofmap,
+T assemble_exterior_facets(DofMapSpan x_dofmap,
                            std::span<const scalar_value_t<T>> x,
                            int num_facets_per_cell,
                            std::span<const std::int32_t> facets,
@@ -102,7 +103,7 @@ T assemble_exterior_facets(mdspan2_t x_dofmap,
 
 /// Assemble functional over interior facets
 template <dolfinx::scalar T>
-T assemble_interior_facets(mdspan2_t x_dofmap,
+T assemble_interior_facets(DofMapSpan x_dofmap,
                            std::span<const scalar_value_t<T>> x,
                            int num_facets_per_cell,
                            std::span<const std::int32_t> facets,
@@ -165,7 +166,7 @@ T assemble_interior_facets(mdspan2_t x_dofmap,
 /// Assemble functional into an scalar with provided mesh geometry.
 template <dolfinx::scalar T, std::floating_point U>
 T assemble_scalar(
-    const fem::Form<T, U>& M, mdspan2_t x_dofmap,
+    const fem::Form<T, U>& M, DofMapSpan x_dofmap,
     std::span<const scalar_value_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)

--- a/cpp/dolfinx/fem/assemble_scalar_impl.h
+++ b/cpp/dolfinx/fem/assemble_scalar_impl.h
@@ -22,7 +22,7 @@ namespace dolfinx::fem::impl
 {
 /// Assemble functional over cells
 template <dolfinx::scalar T>
-T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_type_t<T>> x,
+T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_t<T>> x,
                  std::span<const std::int32_t> cells, FEkernel<T> auto fn,
                  std::span<const T> constants, std::span<const T> coeffs,
                  int cstride)
@@ -32,7 +32,7 @@ T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_type_t<T>> x,
     return value;
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over all cells
   for (std::size_t index = 0; index < cells.size(); ++index)
@@ -59,7 +59,7 @@ T assemble_cells(mdspan2_t x_dofmap, std::span<const scalar_value_type_t<T>> x,
 /// Execute kernel over exterior facets and accumulate result
 template <dolfinx::scalar T>
 T assemble_exterior_facets(mdspan2_t x_dofmap,
-                           std::span<const scalar_value_type_t<T>> x,
+                           std::span<const scalar_value_t<T>> x,
                            int num_facets_per_cell,
                            std::span<const std::int32_t> facets,
                            FEkernel<T> auto fn, std::span<const T> constants,
@@ -71,7 +71,7 @@ T assemble_exterior_facets(mdspan2_t x_dofmap,
     return value;
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
 
   // Iterate over all facets
   assert(facets.size() % 2 == 0);
@@ -103,7 +103,7 @@ T assemble_exterior_facets(mdspan2_t x_dofmap,
 /// Assemble functional over interior facets
 template <dolfinx::scalar T>
 T assemble_interior_facets(mdspan2_t x_dofmap,
-                           std::span<const scalar_value_type_t<T>> x,
+                           std::span<const scalar_value_t<T>> x,
                            int num_facets_per_cell,
                            std::span<const std::int32_t> facets,
                            FEkernel<T> auto fn, std::span<const T> constants,
@@ -116,7 +116,7 @@ T assemble_interior_facets(mdspan2_t x_dofmap,
     return value;
 
   // Create data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
@@ -166,7 +166,7 @@ T assemble_interior_facets(mdspan2_t x_dofmap,
 template <dolfinx::scalar T, std::floating_point U>
 T assemble_scalar(
     const fem::Form<T, U>& M, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, std::span<const T> constants,
+    std::span<const scalar_value_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -17,6 +17,7 @@
 #include <basix/mdspan.hpp>
 #include <cstdint>
 #include <dolfinx/common/IndexMap.h>
+#include <dolfinx/common/types.h>
 #include <dolfinx/mesh/Geometry.h>
 #include <dolfinx/mesh/Mesh.h>
 #include <dolfinx/mesh/Topology.h>
@@ -25,15 +26,8 @@
 #include <optional>
 #include <span>
 #include <vector>
-
 namespace dolfinx::fem::impl
 {
-/// @cond
-using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
-    const std::int32_t,
-    MDSPAN_IMPL_STANDARD_NAMESPACE::dextents<std::size_t, 2>>;
-/// @endcond
-
 /// @brief Apply boundary condition lifting for cell integrals.
 /// @tparam T The scalar type.
 /// @tparam _bs0 The block size of the form test function dof map. If
@@ -73,12 +67,11 @@ using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 /// @param[in] alpha Scaling to apply.
 template <dolfinx::scalar T, int _bs0 = -1, int _bs1 = -1>
 void _lift_bc_cells(
-    std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_t<T>> x, FEkernel<T> auto kernel,
-    std::span<const std::int32_t> cells,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
+    std::span<T> b, DofMapSpan x_dofmap, std::span<const scalar_value_t<T>> x,
+    FEkernel<T> auto kernel, std::span<const std::int32_t> cells,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap1,
     fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
     std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info0,
@@ -260,12 +253,12 @@ void _lift_bc_cells(
 /// permutations are not required.
 template <dolfinx::scalar T, int _bs = -1>
 void _lift_bc_exterior_facets(
-    std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
-    FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
+    std::span<T> b, DofMapSpan x_dofmap, std::span<const scalar_value_t<T>> x,
+    int num_facets_per_cell, FEkernel<T> auto kernel,
+    std::span<const std::int32_t> facets,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap1,
     fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
     std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info0,
@@ -409,12 +402,12 @@ void _lift_bc_exterior_facets(
 /// @param[in] alpha The scaling to apply
 template <dolfinx::scalar T, int _bs = -1>
 void _lift_bc_interior_facets(
-    std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
-    FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
+    std::span<T> b, DofMapSpan x_dofmap, std::span<const scalar_value_t<T>> x,
+    int num_facets_per_cell, FEkernel<T> auto kernel,
+    std::span<const std::int32_t> facets,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap1,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap1,
     fem::DofTransformKernel<T> auto P1T, std::span<const T> constants,
     std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info0,
@@ -631,10 +624,9 @@ void _lift_bc_interior_facets(
 /// mesh
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_cells(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_t<T>> x,
-    std::span<const std::int32_t> cells,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
+    fem::DofTransformKernel<T> auto P0, std::span<T> b, DofMapSpan x_dofmap,
+    std::span<const scalar_value_t<T>> x, std::span<const std::int32_t> cells,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap,
     FEkernel<T> auto kernel, std::span<const T> constants,
     std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info0)
@@ -717,10 +709,10 @@ void assemble_cells(
 /// permutations are not required.
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_exterior_facets(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
+    fem::DofTransformKernel<T> auto P0, std::span<T> b, DofMapSpan x_dofmap,
     std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
-    std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
+    std::tuple<DofMapSpan, int, std::span<const std::int32_t>> dofmap,
     FEkernel<T> auto fn, std::span<const T> constants,
     std::span<const T> coeffs, int cstride,
     std::span<const std::uint32_t> cell_info0,
@@ -813,7 +805,7 @@ void assemble_exterior_facets(
 /// permutations are not required.
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_interior_facets(
-    fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
+    fem::DofTransformKernel<T> auto P0, std::span<T> b, DofMapSpan x_dofmap,
     std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<const DofMap&, int, std::span<const std::int32_t>> dofmap,
@@ -925,9 +917,8 @@ void assemble_interior_facets(
 /// solution' in a Newton method
 /// @param[in] alpha Scaling to apply
 template <dolfinx::scalar T, std::floating_point U>
-void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
-             std::span<const scalar_value_t<T>> x,
-             std::span<const T> constants,
+void lift_bc(std::span<T> b, const Form<T, U>& a, DofMapSpan x_dofmap,
+             std::span<const scalar_value_t<T>> x, std::span<const T> constants,
              const std::map<std::pair<IntegralType, int>,
                             std::pair<std::span<const T>, int>>& coefficients,
              std::span<const T> bc_values1,
@@ -1104,7 +1095,7 @@ void apply_lifting(
       std::shared_ptr<const mesh::Mesh<U>> mesh = a[j]->get().mesh();
       if (!mesh)
         throw std::runtime_error("Unable to extract a mesh.");
-      mdspan2_t x_dofmap = mesh->geometry().dofmap();
+      DofMapSpan x_dofmap = mesh->geometry().dofmap();
       auto x = mesh->geometry().x();
 
       assert(a[j]->get().function_spaces().at(0));
@@ -1145,8 +1136,8 @@ void apply_lifting(
 /// @param[in] coefficients Packed coefficients that appear in `L`.
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_vector(
-    std::span<T> b, const Form<T, U>& L,
-    std::span<const scalar_value_t<T>> x, std::span<const T> constants,
+    std::span<T> b, const Form<T, U>& L, std::span<const scalar_value_t<T>> x,
+    std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
@@ -1162,7 +1153,7 @@ void assemble_vector(
   for (int cell_type_idx = 0; cell_type_idx < num_cell_types; ++cell_type_idx)
   {
     // Geometry dofmap and data
-    mdspan2_t x_dofmap = mesh->geometry().dofmap(cell_type_idx);
+    DofMapSpan x_dofmap = mesh->geometry().dofmap(cell_type_idx);
 
     // Get dofmap data
     assert(L.function_spaces().at(0));
@@ -1189,27 +1180,28 @@ void assemble_vector(
       auto fn = L.kernel(IntegralType::cell, i, cell_type_idx);
       assert(fn);
       auto& [coeffs, cstride] = coefficients.at({IntegralType::cell, i});
-      std::vector<std::int32_t> cells = L.domain(IntegralType::cell, i, cell_type_idx);
+      std::vector<std::int32_t> cells
+          = L.domain(IntegralType::cell, i, cell_type_idx);
       if (bs == 1)
       {
         impl::assemble_cells<T, 1>(
             P0, b, x_dofmap, x, cells,
-            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
-            coeffs, cstride, cell_info0);
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0);
       }
       else if (bs == 3)
       {
         impl::assemble_cells<T, 3>(
             P0, b, x_dofmap, x, cells,
-            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
-            coeffs, cstride, cell_info0);
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0);
       }
       else
       {
         impl::assemble_cells(
             P0, b, x_dofmap, x, cells,
-            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)}, fn, constants,
-            coeffs, cstride, cell_info0);
+            {dofs, bs, L.domain(IntegralType::cell, i, cell_type_idx, *mesh0)},
+            fn, constants, coeffs, cstride, cell_info0);
       }
     }
 

--- a/cpp/dolfinx/fem/assemble_vector_impl.h
+++ b/cpp/dolfinx/fem/assemble_vector_impl.h
@@ -74,7 +74,7 @@ using mdspan2_t = MDSPAN_IMPL_STANDARD_NAMESPACE::mdspan<
 template <dolfinx::scalar T, int _bs0 = -1, int _bs1 = -1>
 void _lift_bc_cells(
     std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, FEkernel<T> auto kernel,
+    std::span<const scalar_value_t<T>> x, FEkernel<T> auto kernel,
     std::span<const std::int32_t> cells,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -94,7 +94,7 @@ void _lift_bc_cells(
   assert(_bs1 < 0 or _bs1 == bs1);
 
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   assert(cells0.size() == cells.size());
   assert(cells1.size() == cells.size());
@@ -261,7 +261,7 @@ void _lift_bc_cells(
 template <dolfinx::scalar T, int _bs = -1>
 void _lift_bc_exterior_facets(
     std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -280,7 +280,7 @@ void _lift_bc_exterior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in bc application
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> Ae, be;
   assert(facets.size() % 2 == 0);
   assert(facets0.size() == facets.size());
@@ -410,7 +410,7 @@ void _lift_bc_exterior_facets(
 template <dolfinx::scalar T, int _bs = -1>
 void _lift_bc_interior_facets(
     std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     FEkernel<T> auto kernel, std::span<const std::int32_t> facets,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap0,
     fem::DofTransformKernel<T> auto P0,
@@ -429,7 +429,7 @@ void _lift_bc_interior_facets(
   const auto [dmap1, bs1, facets1] = dofmap1;
 
   // Data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
@@ -632,7 +632,7 @@ void _lift_bc_interior_facets(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_cells(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x,
+    std::span<const scalar_value_t<T>> x,
     std::span<const std::int32_t> cells,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
     FEkernel<T> auto kernel, std::span<const T> constants,
@@ -646,7 +646,7 @@ void assemble_cells(
   assert(_bs < 0 or _bs == bs);
 
   // Create data structures used in assembly
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * dmap.extent(1));
   std::span<T> _be(be);
 
@@ -718,7 +718,7 @@ void assemble_cells(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_exterior_facets(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<mdspan2_t, int, std::span<const std::int32_t>> dofmap,
     FEkernel<T> auto fn, std::span<const T> constants,
@@ -735,7 +735,7 @@ void assemble_exterior_facets(
   // FIXME: Add proper interface for num_dofs
   // Create data structures used in assembly
   const int num_dofs = dmap.extent(1);
-  std::vector<scalar_value_type_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
+  std::vector<scalar_value_t<T>> coordinate_dofs(3 * x_dofmap.extent(1));
   std::vector<T> be(bs * num_dofs);
   std::span<T> _be(be);
   assert(facets.size() % 2 == 0);
@@ -814,7 +814,7 @@ void assemble_exterior_facets(
 template <dolfinx::scalar T, int _bs = -1>
 void assemble_interior_facets(
     fem::DofTransformKernel<T> auto P0, std::span<T> b, mdspan2_t x_dofmap,
-    std::span<const scalar_value_type_t<T>> x, int num_facets_per_cell,
+    std::span<const scalar_value_t<T>> x, int num_facets_per_cell,
     std::span<const std::int32_t> facets,
     std::tuple<const DofMap&, int, std::span<const std::int32_t>> dofmap,
     FEkernel<T> auto fn, std::span<const T> constants,
@@ -829,7 +829,7 @@ void assemble_interior_facets(
   assert(_bs < 0 or _bs == bs);
 
   // Create data structures used in assembly
-  using X = scalar_value_type_t<T>;
+  using X = scalar_value_t<T>;
   std::vector<X> coordinate_dofs(2 * x_dofmap.extent(1) * 3);
   std::span<X> cdofs0(coordinate_dofs.data(), x_dofmap.extent(1) * 3);
   std::span<X> cdofs1(coordinate_dofs.data() + x_dofmap.extent(1) * 3,
@@ -926,7 +926,7 @@ void assemble_interior_facets(
 /// @param[in] alpha Scaling to apply
 template <dolfinx::scalar T, std::floating_point U>
 void lift_bc(std::span<T> b, const Form<T, U>& a, mdspan2_t x_dofmap,
-             std::span<const scalar_value_type_t<T>> x,
+             std::span<const scalar_value_t<T>> x,
              std::span<const T> constants,
              const std::map<std::pair<IntegralType, int>,
                             std::pair<std::span<const T>, int>>& coefficients,
@@ -1146,7 +1146,7 @@ void apply_lifting(
 template <dolfinx::scalar T, std::floating_point U>
 void assemble_vector(
     std::span<T> b, const Form<T, U>& L,
-    std::span<const scalar_value_type_t<T>> x, std::span<const T> constants,
+    std::span<const scalar_value_t<T>> x, std::span<const T> constants,
     const std::map<std::pair<IntegralType, int>,
                    std::pair<std::span<const T>, int>>& coefficients)
 {
@@ -1301,14 +1301,14 @@ void assemble_vector(
 {
   std::shared_ptr<const mesh::Mesh<U>> mesh = L.mesh();
   assert(mesh);
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     assemble_vector(b, L, mesh->geometry().x(), constants, coefficients);
   }
   else
   {
     auto x = mesh->geometry().x();
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     assemble_vector(b, L, _x, constants, coefficients);
   }
 }

--- a/cpp/dolfinx/fem/assembler.h
+++ b/cpp/dolfinx/fem/assembler.h
@@ -67,7 +67,7 @@ T assemble_scalar(
 {
   std::shared_ptr<const mesh::Mesh<U>> mesh = M.mesh();
   assert(mesh);
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     return impl::assemble_scalar(M, mesh->geometry().dofmap(),
                                  mesh->geometry().x(), constants, coefficients);
@@ -75,7 +75,7 @@ T assemble_scalar(
   else
   {
     auto x = mesh->geometry().x();
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     return impl::assemble_scalar(M, mesh->geometry().dofmap(), _x, constants,
                                  coefficients);
   }
@@ -244,7 +244,7 @@ void assemble_matrix(
 {
   std::shared_ptr<const mesh::Mesh<U>> mesh = a.mesh();
   assert(mesh);
-  if constexpr (std::is_same_v<U, scalar_value_type_t<T>>)
+  if constexpr (std::is_same_v<U, scalar_value_t<T>>)
   {
     impl::assemble_matrix(mat_add, a, mesh->geometry().x(), constants,
                           coefficients, dof_marker0, dof_marker1);
@@ -252,7 +252,7 @@ void assemble_matrix(
   else
   {
     auto x = mesh->geometry().x();
-    std::vector<scalar_value_type_t<T>> _x(x.begin(), x.end());
+    std::vector<scalar_value_t<T>> _x(x.begin(), x.end());
     impl::assemble_matrix(mat_add, a, _x, constants, coefficients, dof_marker0,
                           dof_marker1);
   }

--- a/cpp/dolfinx/fem/discreteoperators.h
+++ b/cpp/dolfinx/fem/discreteoperators.h
@@ -312,7 +312,7 @@ void discrete_curl(const FunctionSpace<T>& V0, const FunctionSpace<T>& V1,
 /// corresponding space to interpolate into.
 /// @param[in] mat_set A functor that sets values in a matrix
 template <dolfinx::scalar T,
-          std::floating_point U = dolfinx::scalar_value_type_t<T>>
+          std::floating_point U = dolfinx::scalar_value_t<T>>
 void discrete_gradient(mesh::Topology& topology,
                        std::pair<std::reference_wrapper<const FiniteElement<U>>,
                                  std::reference_wrapper<const DofMap>>

--- a/cpp/dolfinx/fem/interpolate.h
+++ b/cpp/dolfinx/fem/interpolate.h
@@ -301,7 +301,7 @@ void scatter_values(MPI_Comm comm, std::span<const std::int32_t> src_ranks,
 template <MDSpan U, MDSpan V, dolfinx::scalar T>
 void interpolation_apply(U&& Pi, V&& data, std::span<T> coeffs, int bs)
 {
-  using X = typename dolfinx::scalar_value_type_t<T>;
+  using X = typename dolfinx::scalar_value_t<T>;
 
   // Compute coefficients = Pi * x (matrix-vector multiply)
   if (bs == 1)
@@ -413,7 +413,7 @@ void interpolate_same_map(Function<T, U>& u1, const Function<T, U>& u0,
       = element1->create_interpolation_operator(*element0);
 
   // Iterate over mesh and interpolate on each cell
-  using X = typename dolfinx::scalar_value_type_t<T>;
+  using X = typename dolfinx::scalar_value_t<T>;
   for (std::size_t c = 0; c < cells0.size(); c++)
   {
     // Pack and transform cell dofs to reference ordering
@@ -652,7 +652,7 @@ void interpolate_nonmatching_maps(Function<T, U>& u1,
         coeffs0[dof_bs0 * i + k] = array0[dof_bs0 * dofs0[i] + k];
 
     // Evaluate v at the interpolation points (physical space values)
-    using X = typename dolfinx::scalar_value_type_t<T>;
+    using X = typename dolfinx::scalar_value_t<T>;
     for (std::size_t p = 0; p < Xshape[0]; ++p)
     {
       for (int k = 0; k < bs0; ++k)

--- a/cpp/dolfinx/fem/traits.h
+++ b/cpp/dolfinx/fem/traits.h
@@ -26,7 +26,7 @@ concept DofTransformKernel
 /// must satisfy this concept.
 template <class U, class T>
 concept FEkernel = std::is_invocable_v<U, T*, const T*, const T*,
-                                       const scalar_value_type_t<T>*,
+                                       const scalar_value_t<T>*,
                                        const int*, const std::uint8_t*>;
 
 } // namespace dolfinx::fem

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -495,8 +495,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -506,8 +505,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -576,8 +574,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -587,8 +584,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -678,8 +674,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -689,8 +684,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*,
-              const typename scalar_value_type<T>::value_type*, const int*,
+              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -914,8 +908,7 @@ Expression<T, U> create_expression(
          static_cast<std::size_t>(e.entity_dimension)};
   std::vector<std::size_t> value_shape(e.value_shape,
                                        e.value_shape + e.num_components);
-  std::function<void(T*, const T*, const T*,
-                     const typename scalar_value_type<T>::value_type*,
+  std::function<void(T*, const T*, const T*, const scalar_value_type_t<T>*,
                      const int*, const std::uint8_t*)>
       tabulate_tensor = nullptr;
   if constexpr (std::is_same_v<T, float>)
@@ -924,8 +917,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<float>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*,
-        const typename scalar_value_type<T>::value_type*, const int*,
+        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex64);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -935,8 +927,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<double>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*,
-        const typename scalar_value_type<T>::value_type*, const int*,
+        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex128);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS

--- a/cpp/dolfinx/fem/utils.h
+++ b/cpp/dolfinx/fem/utils.h
@@ -357,7 +357,7 @@ std::vector<std::string> get_constant_names(const ufcx_form& ufcx_form);
 /// @param[in] mesh The mesh of the domain.
 ///
 /// @pre Each value in `subdomains` must be sorted by domain id.
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form_factory(
     const std::vector<std::reference_wrapper<const ufcx_form>>& ufcx_forms,
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -495,7 +495,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -505,7 +505,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -574,7 +574,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -584,7 +584,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -674,7 +674,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<float>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex64);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -684,7 +684,7 @@ Form<T, U> create_form_factory(
         else if constexpr (std::is_same_v<T, std::complex<double>>)
         {
           k = reinterpret_cast<void (*)(
-              T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+              T*, const T*, const T*, const scalar_value_t<T>*, const int*,
               const unsigned char*)>(integral->tabulate_tensor_complex128);
         }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -764,7 +764,7 @@ Form<T, U> create_form_factory(
 /// @param[in] mesh Mesh of the domain. This is required if the form has
 /// no arguments, e.g. a functional.
 /// @return A Form
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form(
     const ufcx_form& ufcx_form,
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -824,7 +824,7 @@ Form<T, U> create_form(
 /// @param[in] mesh Mesh of the domain. This is required if the form has
 /// no arguments, e.g. a functional.
 /// @return A Form
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Form<T, U> create_form(
     ufcx_form* (*fptr)(),
     const std::vector<std::shared_ptr<const FunctionSpace<U>>>& spaces,
@@ -876,7 +876,7 @@ FunctionSpace<T> create_functionspace(
 }
 
 /// @brief Create Expression from UFC
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Expression<T, U> create_expression(
     const ufcx_expression& e,
     const std::vector<std::shared_ptr<const Function<T, U>>>& coefficients,
@@ -908,7 +908,7 @@ Expression<T, U> create_expression(
          static_cast<std::size_t>(e.entity_dimension)};
   std::vector<std::size_t> value_shape(e.value_shape,
                                        e.value_shape + e.num_components);
-  std::function<void(T*, const T*, const T*, const scalar_value_type_t<T>*,
+  std::function<void(T*, const T*, const T*, const scalar_value_t<T>*,
                      const int*, const std::uint8_t*)>
       tabulate_tensor = nullptr;
   if constexpr (std::is_same_v<T, float>)
@@ -917,7 +917,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<float>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+        T*, const T*, const T*, const scalar_value_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex64);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -927,7 +927,7 @@ Expression<T, U> create_expression(
   else if constexpr (std::is_same_v<T, std::complex<double>>)
   {
     tabulate_tensor = reinterpret_cast<void (*)(
-        T*, const T*, const T*, const scalar_value_type_t<T>*, const int*,
+        T*, const T*, const T*, const scalar_value_t<T>*, const int*,
         const unsigned char*)>(e.tabulate_tensor_complex128);
   }
 #endif // DOLFINX_NO_STDC_COMPLEX_KERNELS
@@ -941,7 +941,7 @@ Expression<T, U> create_expression(
 
 /// @brief Create Expression from UFC input (with named coefficients and
 /// constants).
-template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
 Expression<T, U> create_expression(
     const ufcx_expression& e,
     const std::map<std::string, std::shared_ptr<const Function<T, U>>>&

--- a/cpp/dolfinx/io/VTKFile.h
+++ b/cpp/dolfinx/io/VTKFile.h
@@ -80,7 +80,7 @@ public:
   /// @param[in] u List of functions to write to file
   /// @param[in] t Time parameter to associate with @p u
   /// @pre All Functions in `u` must share the same mesh
-  template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+  template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
   void
   write(const std::vector<std::reference_wrapper<const fem::Function<T, U>>>& u,
         double t);

--- a/cpp/dolfinx/io/XDMFFile.h
+++ b/cpp/dolfinx/io/XDMFFile.h
@@ -147,7 +147,7 @@ public:
   /// @param[in] t Time stamp to associate with `u`.
   /// @param[in] mesh_xpath XPath for a Grid under which `u` will be
   /// inserted.
-  template <dolfinx::scalar T, std::floating_point U = scalar_value_type_t<T>>
+  template <dolfinx::scalar T, std::floating_point U = scalar_value_t<T>>
   void write_function(const fem::Function<T, U>& u, double t,
                       std::string mesh_xpath
                       = "/Xdmf/Domain/Grid[@GridType='Uniform'][1]");

--- a/cpp/dolfinx/io/xdmf_function.cpp
+++ b/cpp/dolfinx/io/xdmf_function.cpp
@@ -184,8 +184,8 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
         = shape_to_string(value_shape).c_str();
     attr_node.append_attribute("Center") = cell_centred ? "Cell" : "Node";
 
-    std::span<const scalar_value_type_t<T>> u;
-    std::vector<scalar_value_type_t<T>> _data;
+    std::span<const scalar_value_t<T>> u;
+    std::vector<scalar_value_t<T>> _data;
     if constexpr (!std::is_scalar_v<T>)
     {
       // Complex-valued case
@@ -200,7 +200,7 @@ void xdmf_function::add_function(MPI_Comm comm, const fem::Function<T, U>& u,
         std::ranges::transform(data_values, _data.begin(),
                                [](auto x) { return x.imag(); });
       }
-      u = std::span<const scalar_value_type_t<T>>(_data);
+      u = std::span<const scalar_value_t<T>>(_data);
     }
     else
       u = std::span<const T>(data_values);

--- a/cpp/dolfinx/la/Vector.h
+++ b/cpp/dolfinx/la/Vector.h
@@ -274,7 +274,7 @@ auto norm(const V& x, Norm type = Norm::l2)
   {
     std::int32_t size_local = x.bs() * x.index_map()->size_local();
     std::span<const T> data = x.array().subspan(0, size_local);
-    using U = typename dolfinx::scalar_value_type_t<T>;
+    using U = typename dolfinx::scalar_value_t<T>;
     U local_l1
         = std::accumulate(data.begin(), data.end(), U(0),
                           [](auto norm, auto x) { return norm + std::abs(x); });
@@ -311,7 +311,7 @@ template <class V>
 void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 {
   using T = typename V::value_type;
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // Loop over each vector in basis
   for (std::size_t i = 0; i < basis.size(); ++i)
@@ -353,9 +353,9 @@ void orthonormalize(std::vector<std::reference_wrapper<V>> basis)
 template <class V>
 bool is_orthonormal(
     std::vector<std::reference_wrapper<const V>> basis,
-    dolfinx::scalar_value_type_t<typename V::value_type> eps
+    dolfinx::scalar_value_t<typename V::value_type> eps
     = std::numeric_limits<
-        dolfinx::scalar_value_type_t<typename V::value_type>>::epsilon())
+        dolfinx::scalar_value_t<typename V::value_type>>::epsilon())
 {
   using T = typename V::value_type;
   for (std::size_t i = 0; i < basis.size(); i++)

--- a/python/dolfinx/wrappers/fem.cpp
+++ b/python/dolfinx/wrappers/fem.cpp
@@ -300,7 +300,7 @@ void declare_function_space(nb::module_& m, std::string type)
 template <typename T>
 void declare_objects(nb::module_& m, const std::string& type)
 {
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // dolfinx::fem::DirichletBC
   std::string pyclass_name = std::string("DirichletBC_") + type;
@@ -632,7 +632,7 @@ void declare_objects(nb::module_& m, const std::string& type)
 template <typename T>
 void declare_form(nb::module_& m, std::string type)
 {
-  using U = typename dolfinx::scalar_value_type_t<T>;
+  using U = typename dolfinx::scalar_value_t<T>;
 
   // dolfinx::fem::Form
   std::string pyclass_name_form = std::string("Form_") + type;

--- a/python/dolfinx/wrappers/la.cpp
+++ b/python/dolfinx/wrappers/la.cpp
@@ -196,7 +196,7 @@ void declare_functions(nb::module_& m)
   m.def(
       "is_orthonormal",
       [](std::vector<const dolfinx::la::Vector<T>*> basis,
-         dolfinx::scalar_value_type_t<T> eps)
+         dolfinx::scalar_value_t<T> eps)
       {
         std::vector<std::reference_wrapper<const dolfinx::la::Vector<T>>>
             _basis;


### PR DESCRIPTION
Contains multiple changes to the type system.

1. Generalizes `dolfinx::scalar` concept to allow for general `std::complex<T>` types (before only `float` and `double` supported).
2. Renames trait `dolfinx::scalar_value_type` to `dolfinx::scalar_value` and its short notation `scalar_value_type_t` to `scalar_value_t` (removes duplicate 'type'). Also renames internal trait variable from `value_type` to `type` to highlight different implications.
3. Introduces `DofMapSpan` type in `types.h` in favor of multiple definitions of `mdspan2_t` types. (This caused undefined definition errors when including assembler implementation files)
4. Introduce namespace alias `md` for `MDSPAN_IMPL_STANDARD_NAMESPACE` - following style chosen in https://github.com/FEniCS/basix/pull/902  (should one globally rename `MDSPAN_IMPL_STANDARD_NAMESPACE` to `md` with this?)