### PR TITLE
Set max doc length to 75 for dolfinx/ and demo/

### DIFF
--- a/python/dolfinx/pyproject.toml
+++ b/python/dolfinx/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.ruff]
 extend = "../pyproject.toml"
 
-[tool.ruff.lint.flake8-import-conventions]
-banned-from = ["ufl"]
-
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 75


### PR DESCRIPTION
Sphinx requires max line length of 79 see https://documentation-style-guide-sphinx.readthedocs.io/en/latest/style-guide.html#line-length. 

Dolfinx seems to be already mostly formatted with `max-doc-length = 75`  - this is however not checked with ruff. 